### PR TITLE
Update outdated ModSaber reference to current Mod Manager

### DIFF
--- a/beginners-guide.md
+++ b/beginners-guide.md
@@ -37,7 +37,7 @@ The `BeatSaver Downloader` Plugin allows you to download maps in-game using the 
 
 ## Beat Saver
 [Beat Saver](https://www.beatsaver.com) is the central repository that holds nearly all custom songs/maps for Beat Saber.
-You can manually place the zip files downloaded from Beat Saver into the `CustomSongs` folder in your Beat Saber directory, use the In-Game Downloader Plugin, or use the OneClick Install button if you're using the [ModSaber Installer](https://www.modsaber.org/).
+You can manually place the zip files downloaded from Beat Saver into the `CustomSongs` folder in your Beat Saber directory, use the In-Game Downloader Plugin, or use the OneClick Install button if you're using the [BeatSaber Mod Manager](https://github.com/beat-saber-modding-group/BeatSaberModInstaller/releases/latest).
 
 There are a couple more resources to help you find songs over in the [FAQ](faq#more-songs)
 


### PR DESCRIPTION
The beginner's guide still mentions and links to the ModSaber Installer as the OneClick Install solution for Beat Saver.

This patch updates this reference to the current BeatSaber Mod Manager, which supports map OneClick installation since v3.2.0.